### PR TITLE
Enable --sdf option on command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-[![npm version](https://badge.fury.io/js/%40mapbox%2Fspritezero-cli.svg)](https://badge.fury.io/js/%40mapbox%2Fspritezero-cli)
-[![build status](https://secure.travis-ci.org/mapbox/spritezero-cli.svg?branch=master)](http://travis-ci.org/mapbox/spritezero-cli)
+# @elastic/spritezero-cli
 
-# spritezero-cli
+A command-line interface to [elastic/spritezero](https://github.com/elastic/spritezero).
 
-A command-line interface to [spritezero](https://github.com/mapbox/spritezero).
+## WTF? (Why The Fork?)
+See [elastic/spritezero](https://github.com/elastic/spritezero#wtf-why-the-fork)
 
 ## Installation
 
-    npm install -g @mapbox/spritezero-cli
+    npm install -g @elastic/spritezero-cli
 
 ## Usage
 
@@ -16,7 +16,7 @@ A command-line interface to [spritezero](https://github.com/mapbox/spritezero).
       --retina      shorthand for --ratio=2
       --ratio=[n]   pixel ratio
       --unique      map identical images to multiple names
-      --sdf         generate sdf images
+      --sdf         generate sdf sprites
 
 Spritezero reads an input directory containing SVG files and generates a JSON
 layout file and PNG spritesheet.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A command-line interface to [spritezero](https://github.com/mapbox/spritezero).
       --retina      shorthand for --ratio=2
       --ratio=[n]   pixel ratio
       --unique      map identical images to multiple names
+      --sdf         generate sdf images
 
 Spritezero reads an input directory containing SVG files and generates a JSON
 layout file and PNG spritesheet.

--- a/bin/spritezero
+++ b/bin/spritezero
@@ -7,7 +7,7 @@ var multiline = require('multiline');
 var path = require('path');
 var stringify = require('json-stable-stringify');
 var argv = require('minimist')(process.argv.slice(2), {
-    boolean: ['retina', 'unique', 'h', 'help']
+    boolean: ['retina', 'unique', 'sdf', 'h', 'help']
 });
 
 function filepaths (dir) {
@@ -43,6 +43,7 @@ if (argv.help || argv._.length < 2) {
 
 var ratio = 1;
 var unique = false;
+var sdf = false;
 
 if (argv.retina) {
     ratio = 2;
@@ -52,6 +53,10 @@ if (argv.retina) {
 
 if (argv.unique) {
     unique = true;
+}
+
+if (argv.sdf) {
+    sdf = true;
 }
 
 var outfile = argv._[0];
@@ -99,6 +104,6 @@ q.awaitAll(function (err, buffers) {
     }
 
     var genLayout = unique ? spritezero.generateLayoutUnique : spritezero.generateLayout;
-    genLayout({ imgs: buffers, pixelRatio: ratio, format: true }, saveLayout);
-    genLayout({ imgs: buffers, pixelRatio: ratio, format: false }, saveImage);
+    genLayout({ imgs: buffers, pixelRatio: ratio, sdf: sdf, format: true }, saveLayout);
+    genLayout({ imgs: buffers, pixelRatio: ratio, sdf: sdf, format: false }, saveImage);
 });

--- a/bin/spritezero
+++ b/bin/spritezero
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var spritezero = require('@mapbox/spritezero');
+var spritezero = require('@elastic/spritezero');
 var fs = require('fs');
 var queue = require('queue-async');
 var multiline = require('multiline');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "multiline": "^1.0.2",
     "queue-async": "^1.2.1",
     "json-stable-stringify": "^1.0.1",
-    "@mapbox/spritezero": "~5.0.0"
+    "@mapbox/spritezero": "github:nickpeihl/spritezero#sdf-option"
   },
   "devDependencies": {
     "eslint": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@mapbox/spritezero-cli",
+  "name": "@elastic/spritezero-cli",
   "version": "2.1.0",
   "main": "index.js",
   "description": "a command-line interface for spritezero generation of raster sprites from SVG input",
   "author": "Tom MacWright",
   "license": "ISC",
-  "repository": "mapbox/spritezero-cli",
-  "bugs": "https://github.com/mapbox/spritezero-cli/issues",
+  "repository": "elastic/spritezero-cli",
+  "bugs": "https://github.com/elastic/spritezero-cli/issues",
   "bin": {
     "spritezero": "bin/spritezero"
   },
@@ -21,14 +21,14 @@
     "multiline": "^1.0.2",
     "queue-async": "^1.2.1",
     "json-stable-stringify": "^1.0.1",
-    "@mapbox/spritezero": "github:nickpeihl/spritezero#sdf-option"
+    "@elastic/spritezero": "^6.2.0"
   },
   "devDependencies": {
     "eslint": "^4.0.0",
     "tap": "^10.1.0"
   },
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "lint": "eslint bin/spritezero test/",


### PR DESCRIPTION
This updates the spritezero dependency to @elastic/spritezero@6.2.0 and adds the `--sdf` option to spritezero. The `--sdf` option generates sprites with signed distance fields which can be colored and resized dynamically in mapbox-gl clients.